### PR TITLE
1478 - Removed SSL3 compatibility

### DIFF
--- a/modules/nginx/templates/nginx.conf.erb
+++ b/modules/nginx/templates/nginx.conf.erb
@@ -41,7 +41,7 @@ http {
 
   ssl_ciphers "EECDH+ECDSA+AESGCM EECDH+aRSA+AESGCM EECDH+ECDSA+SHA384 EECDH+ECDSA+SHA256 EECDH+aRSA+SHA384 EECDH+aRSA+SHA256 EECDH EDH+aRSA -3DES DES-CBC3-SHA !aNULL !eNULL !LOW !MD5 !EXP !PSK !SRP !DSS !RC4";
   ssl_prefer_server_ciphers on;
-  ssl_protocols SSLv3 TLSv1 TLSv1.1 TLSv1.2;
+  ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
   <% if ssl_session_cache == 'on' %>
   ssl_session_cache shared:SSL:1m;
   <% else %>


### PR DESCRIPTION
This is the quick fix for POODLE Vulnerability
http://googleonlinesecurity.blogspot.de/2014/10/this-poodle-bites-exploiting-ssl-30.html 
