### PR TITLE
kill tcpdump instead of using -G, because it's more accurate

### DIFF
--- a/modules/nagios/files/check_bandwidth
+++ b/modules/nagios/files/check_bandwidth
@@ -31,12 +31,9 @@ if __name__ == "__main__":
   crit = int(sys.argv[2])
 
   process = subprocess.Popen(
-    ["sudo", "tcpdump", "-q", "-s", "64", "-W", "1", "-w", "-"],
+    ["sudo", "timeout", "-s", "SIGTERM", str(INTERVAL), "tcpdump", "-q", "-s", "64", "-W", "1", "-w", "-"],
     stdout=subprocess.PIPE, stderr=subprocess.PIPE)
   time.sleep(INTERVAL)
-  kill = subprocess.Popen(
-      ["sudo", "kill", "-TERM", str(process.pid)],
-      stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
   mac = getmacaddress()
 

--- a/modules/nagios/files/check_bandwidth
+++ b/modules/nagios/files/check_bandwidth
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-import os, re, subprocess, sys, socket, struct, fcntl
+import os, re, subprocess, sys, socket, struct, fcntl, time
 
 INTERVAL = 5
 
@@ -31,8 +31,13 @@ if __name__ == "__main__":
   crit = int(sys.argv[2])
 
   process = subprocess.Popen(
-    ["sudo", "tcpdump", "-q", "-s", "64", "-G", str(INTERVAL), "-W", "1", "-w", "-"],
+    ["sudo", "tcpdump", "-q", "-s", "64", "-W", "1", "-w", "-"],
     stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+  time.sleep(INTERVAL)
+  kill = subprocess.Popen(
+      ["sudo", "kill", "-TERM", str(process.pid)],
+      stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
   mac = getmacaddress()
 
   total = {"rx": 0, "tx": 0}

--- a/modules/nagios/files/check_bandwidth
+++ b/modules/nagios/files/check_bandwidth
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-import os, re, subprocess, sys, socket, struct, fcntl, time
+import os, re, subprocess, sys, socket, struct, fcntl
 
 INTERVAL = 5
 
@@ -33,7 +33,7 @@ if __name__ == "__main__":
   process = subprocess.Popen(
     ["sudo", "timeout", "-s", "SIGTERM", str(INTERVAL), "tcpdump", "-q", "-s", "64", "-W", "1", "-w", "-"],
     stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-  time.sleep(INTERVAL)
+  process.wait()
 
   mac = getmacaddress()
 


### PR DESCRIPTION
The  G option seems not to be very accurate.  
Here is an example from my server:
$ for i in {1..10} ; do ( time tcpdump -q -s 64 -G 5 -W 1 -w - ) 2>&1 | grep real ; done
real    0m4.582s
real    0m5.031s
real    0m5.915s
real    0m5.403s
real    0m7.011s
real    0m4.435s
real    0m5.739s
real    0m4.159s
real    0m4.967s
real    0m5.579s

The use of kill is encouraged in the manual: "Tcpdump  will, if not run with the -c flag, continue capturing packets until it is interrupted by a SIGINT signal (generated, for example, by typing your interrupt  character,  typically  control-C)  or a SIGTERM signal (typically generated with the kill(1) command);"